### PR TITLE
Add per-counter graph spacing option (#93)

### DIFF
--- a/TaskbarMonitor/DeskBand.cs
+++ b/TaskbarMonitor/DeskBand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
@@ -31,7 +32,10 @@ namespace TaskbarMonitor
                 TaskbarInfo.TaskbarOrientationChanged += TaskbarInfo_TaskbarOrientationChanged;
                 Monitor monitor = Monitor.GetInstance(opt);
                 var ctl = new SystemWatcherControl(monitor, false, this);
-                Options.MinHorizontalSize = new Size((ctl.Options.HistorySize + 10) * ctl.CountersCount, CSDeskBand.CSDeskBandOptions.TaskbarHorizontalHeightSmall);
+                int totalWidth = ctl.Options.CounterOptions
+                    .Where(x => x.Value.Enabled)
+                    .Sum(x => ctl.Options.HistorySize + x.Value.Padding);
+                Options.MinHorizontalSize = new Size(totalWidth, CSDeskBand.CSDeskBandOptions.TaskbarHorizontalHeightSmall);
                 
                 ctl.OnChangeSize += Ctl_OnChangeSize;
                 //Options.HeightCanChange = false;                

--- a/TaskbarMonitor/OptionForm.Designer.cs
+++ b/TaskbarMonitor/OptionForm.Designer.cs
@@ -34,6 +34,8 @@
             this.labelTitle = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.editHistorySize = new System.Windows.Forms.NumericUpDown();
+            this.editPadding = new System.Windows.Forms.NumericUpDown();
+            this.labelPadding = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.panelMenu = new System.Windows.Forms.Panel();
             this.btnMenuMultiMonitor = new System.Windows.Forms.Button();
@@ -138,6 +140,7 @@
             this.buttonApply = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.editHistorySize)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.editPadding)).BeginInit();
             this.panelMenu.SuspendLayout();
             this.panel3.SuspendLayout();
             this.contextMenuStripReplicateSettings.SuspendLayout();
@@ -326,7 +329,7 @@
             // 
             // buttonReplicateSettings
             // 
-            this.buttonReplicateSettings.Location = new System.Drawing.Point(249, 355);
+            this.buttonReplicateSettings.Location = new System.Drawing.Point(249, 388);
             this.buttonReplicateSettings.Menu = this.contextMenuStripReplicateSettings;
             this.buttonReplicateSettings.Name = "buttonReplicateSettings";
             this.buttonReplicateSettings.ShowMenuUnderCursor = true;
@@ -367,7 +370,7 @@
             this.groupBox4.Controls.Add(this.listSummaryPosition);
             this.groupBox4.Controls.Add(this.label20);
             this.groupBox4.Controls.Add(this.checkShowSummary);
-            this.groupBox4.Location = new System.Drawing.Point(8, 203);
+            this.groupBox4.Location = new System.Drawing.Point(8, 236);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Size = new System.Drawing.Size(403, 146);
             this.groupBox4.TabIndex = 9;
@@ -474,7 +477,7 @@
             this.groupBox3.Controls.Add(this.label7);
             this.groupBox3.Controls.Add(this.label3);
             this.groupBox3.Controls.Add(this.listShowTitle);
-            this.groupBox3.Location = new System.Drawing.Point(8, 102);
+            this.groupBox3.Location = new System.Drawing.Point(8, 135);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(403, 95);
             this.groupBox3.TabIndex = 7;
@@ -553,9 +556,11 @@
             this.groupBox2.Controls.Add(this.listGraphType);
             this.groupBox2.Controls.Add(this.label21);
             this.groupBox2.Controls.Add(this.checkInvertOrder);
+            this.groupBox2.Controls.Add(this.labelPadding);
+            this.groupBox2.Controls.Add(this.editPadding);
             this.groupBox2.Location = new System.Drawing.Point(5, 7);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(404, 89);
+            this.groupBox2.Size = new System.Drawing.Size(404, 122);
             this.groupBox2.TabIndex = 6;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Main settings";
@@ -640,9 +645,43 @@
             this.checkInvertOrder.TabIndex = 9;
             this.checkInvertOrder.UseVisualStyleBackColor = true;
             this.checkInvertOrder.CheckedChanged += new System.EventHandler(this.checkInvertOrder_CheckedChanged);
-            // 
+            //
+            // labelPadding
+            //
+            this.labelPadding.AutoSize = true;
+            this.labelPadding.Location = new System.Drawing.Point(8, 95);
+            this.labelPadding.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelPadding.Name = "labelPadding";
+            this.labelPadding.Size = new System.Drawing.Size(70, 14);
+            this.labelPadding.TabIndex = 14;
+            this.labelPadding.Text = "Padding (px):";
+            //
+            // editPadding
+            //
+            this.editPadding.Location = new System.Drawing.Point(90, 92);
+            this.editPadding.Margin = new System.Windows.Forms.Padding(2);
+            this.editPadding.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.editPadding.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.editPadding.Name = "editPadding";
+            this.editPadding.Size = new System.Drawing.Size(75, 22);
+            this.editPadding.TabIndex = 15;
+            this.editPadding.Value = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.editPadding.ValueChanged += new System.EventHandler(this.editPadding_ValueChanged);
+            //
             // panel4
-            // 
+            //
             this.panel4.BackColor = System.Drawing.Color.Transparent;
             this.panel4.Controls.Add(this.buttonDown);
             this.panel4.Controls.Add(this.buttonUp);
@@ -1394,6 +1433,7 @@
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.editHistorySize)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.editPadding)).EndInit();
             this.panelMenu.ResumeLayout(false);
             this.panel3.ResumeLayout(false);
             this.contextMenuStripReplicateSettings.ResumeLayout(false);
@@ -1432,6 +1472,8 @@
 
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.NumericUpDown editHistorySize;
+        private System.Windows.Forms.NumericUpDown editPadding;
+        private System.Windows.Forms.Label labelPadding;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Panel panelMenu;
         private System.Windows.Forms.Panel panel3;

--- a/TaskbarMonitor/OptionForm.cs
+++ b/TaskbarMonitor/OptionForm.cs
@@ -309,7 +309,8 @@ namespace TaskbarMonitor
                 Options.CounterOptions[item].SummaryPosition = ActiveCounter.SummaryPosition;
                 Options.CounterOptions[item].ShowTitleShadowOnHover = ActiveCounter.ShowTitleShadowOnHover;
                 Options.CounterOptions[item].ShowCurrentValueShadowOnHover = ActiveCounter.ShowCurrentValueShadowOnHover;
-                Options.CounterOptions[item].TitlePosition = ActiveCounter.TitlePosition;                
+                Options.CounterOptions[item].TitlePosition = ActiveCounter.TitlePosition;
+                Options.CounterOptions[item].Padding = ActiveCounter.Padding;
 
             }
         }
@@ -327,6 +328,7 @@ namespace TaskbarMonitor
             listSummaryPosition.Text = ActiveCounter.SummaryPosition.ToString();
             checkInvertOrder.Checked = ActiveCounter.InvertOrder;
             checkSeparateScales.Checked = ActiveCounter.SeparateScales;
+            editPadding.Value = Math.Max(editPadding.Minimum, Math.Min(editPadding.Maximum, ActiveCounter.Padding));
             checkTitleShadowHover.Checked = ActiveCounter.ShowTitleShadowOnHover;
             checkValueShadowHover.Checked = ActiveCounter.ShowCurrentValueShadowOnHover;
             listTitlePosition.Text = ActiveCounter.TitlePosition.ToString();
@@ -432,6 +434,13 @@ namespace TaskbarMonitor
         {
             if (initializing) return;
             ActiveCounter.InvertOrder = checkInvertOrder.Checked;
+            UpdatePreview();
+        }
+
+        private void editPadding_ValueChanged(object sender, EventArgs e)
+        {
+            if (initializing) return;
+            ActiveCounter.Padding = (int)editPadding.Value;
             UpdatePreview();
         }
 

--- a/TaskbarMonitor/Options.cs
+++ b/TaskbarMonitor/Options.cs
@@ -16,7 +16,7 @@ namespace TaskbarMonitor
             LIGHT,
             CUSTOM            
         }
-        public static readonly int LATESTOPTIONSVERSION = 5;
+        public static readonly int LATESTOPTIONSVERSION = 6;
         public int OptionsVersion = LATESTOPTIONSVERSION;
         public Dictionary<string, CounterOptions> CounterOptions { get; set; }
         public int HistorySize { get; set; } = 50;
@@ -51,6 +51,7 @@ namespace TaskbarMonitor
                 opt.CounterOptions[item.Key].SeparateScales = item.Value.SeparateScales;
                 opt.CounterOptions[item.Key].GraphType = item.Value.GraphType;
                 opt.CounterOptions[item.Key].Order = item.Value.Order;
+                opt.CounterOptions[item.Key].Padding = item.Value.Padding;
             }
 
             opt.EnableOnAllMonitors = this.EnableOnAllMonitors;
@@ -296,9 +297,19 @@ namespace TaskbarMonitor
                     if (item.Key.StartsWith("GPU") && item.Value.GraphType != Counters.ICounter.CounterType.SINGLE)
                         item.Value.GraphType = Counters.ICounter.CounterType.SINGLE;
                 }
-                
+
             }
-            this.OptionsVersion = LATESTOPTIONSVERSION;              
+            if (this.OptionsVersion <= 6)
+            {
+                // Pre-v6 configs had a hardcoded 10px gap; preserve that as the per-counter default so existing layouts don't shift.
+                foreach (var item in this.CounterOptions)
+                {
+                    if (item.Value.Padding == 0)
+                        item.Value.Padding = 10;
+                }
+                ret = true;
+            }
+            this.OptionsVersion = LATESTOPTIONSVERSION;
             return ret;
         }
     }
@@ -329,6 +340,7 @@ namespace TaskbarMonitor
         public bool SeparateScales { get; set; } = true;
         public TaskbarMonitor.Counters.ICounter.CounterType GraphType { get; set; }
         public int? Order { get; set; }
+        public int Padding { get; set; } = 10;
     }
 
     public class MonitorOptions

--- a/TaskbarMonitor/SystemWatcherControl.cs
+++ b/TaskbarMonitor/SystemWatcherControl.cs
@@ -324,15 +324,19 @@ namespace TaskbarMonitor
             else if (taskbarWidth == 0 && taskbarHeight > 0)
                 VerticalTaskbarMode = false;
 
-            int counterSize = (Options.HistorySize + 10);
-            int controlWidth = counterSize * CountersCount;
+            var enabledCounters = Options.CounterOptions.Where(x => x.Value.Enabled).ToList();
+            int controlWidth = enabledCounters.Sum(x => Options.HistorySize + x.Value.Padding);
             int controlHeight = minimumHeight;
 
             if (VerticalTaskbarMode && taskbarWidth < controlWidth)
             {
+                // Each counter is a fixed graph width plus its own padding; size the wrap math by the widest cell so we never overflow.
+                int maxPadding = enabledCounters.Count > 0 ? enabledCounters.Max(x => x.Value.Padding) : 10;
+                int counterSize = Options.HistorySize + maxPadding;
                 int countersPerLine = Convert.ToInt32(Math.Floor((float)taskbarWidth / (float)counterSize));
+                if (countersPerLine < 1) countersPerLine = 1;
                 controlWidth = counterSize * countersPerLine;
-                controlHeight = Convert.ToInt32(Math.Ceiling((float)CountersCount / (float)countersPerLine)) * (30 + 10);
+                controlHeight = Convert.ToInt32(Math.Ceiling((float)CountersCount / (float)countersPerLine)) * (30 + maxPadding);
             }
             if (VerticalTaskbarMode)
             {
@@ -550,11 +554,11 @@ namespace TaskbarMonitor
                     }
 
 
-                    graphPosition += Options.HistorySize + 10;
+                    graphPosition += Options.HistorySize + opt.Padding;
                     if (VerticalTaskbarMode && graphPosition >= this.Size.Width)
                     {
                         graphPosition = 0;
-                        graphPositionY += (maximumHeight + 10);
+                        graphPositionY += (maximumHeight + opt.Padding);
                     }
 
                 }


### PR DESCRIPTION
Closes #93.

Each counter now has its own `Padding` setting (default 10px),
configurable in **Settings → Counters → Main settings**. This replaces
the hardcoded `HistorySize + 10` gap in three places: the paint loop,
`AdjustControlSize`, and the Win10 deskband min-size calc. Vertical-mode
row gaps use the same value.

Schema bumped to `OptionsVersion = 6` with an upgrade step that
backfills `Padding = 10` so existing configs render identically until
the user dials it up.

Tested on Windows 11 via the standalone `TaskbarMonitorWindows11.exe`
host. The Win10 Deskband path was changed for consistency, but not
runtime-tested.
